### PR TITLE
Matched property naming on SolidProver model

### DIFF
--- a/generators/app/templates/src/app/register/register.component.html
+++ b/generators/app/templates/src/app/register/register.component.html
@@ -17,9 +17,9 @@
   <!-- Provider cards -->
   <div class="provider-card-container">
     <div class="provider-card" *ngFor="let provider of availableProviders">
-      <img [src]="provider.providerImage" class="provider-logo">
-      <h2>{{ provider.providerName }}</h2>
-      <p>{{ provider.providerDesc }}</p>
+      <img [src]="provider.image" class="provider-logo">
+      <h2>{{ provider.name }}</h2>
+      <p>{{ provider.desc }}</p>
     </div>
   </div>
 


### PR DESCRIPTION
Simple fix for the register page where there was a mismatch on the property name for SolidProviders

![solid-inrupt-provider-name-bug](https://user-images.githubusercontent.com/1281399/47271314-e27e3780-d52c-11e8-9cd1-2e3c77bd1e5d.JPG)

![solid-inrupt-provider-name-bug-fixed](https://user-images.githubusercontent.com/1281399/47271323-05a8e700-d52d-11e8-95f1-34a54b56bfa4.JPG)
